### PR TITLE
Typo

### DIFF
--- a/assn/autosdb/index.php
+++ b/assn/autosdb/index.php
@@ -58,7 +58,7 @@ target="_blank">PDO</a> to connect to a database.
 <a href="http://php.net/manual/en/pdo.prepare.php" target="_new">PHP PDO Prepared Statements</a>
 </li>
 <li>
-You can look though the sample code from the lecture. It has examples
+You can look through the sample code from the lecture. It has examples
 of using PDO to communicate with a database:
 <pre>
 <a href="http://www.wa4e.com/code/pdo.zip" target="_blank">http://www.wa4e.com/code/pdo.zip</a>


### PR DESCRIPTION
From student feedback on the Coursera page (which is correct) 
I think it should be "through" instead of "though" in the following sentence:

You can look *though* the sample code from the lecture. It has examples of using PDO to communicate with a database:
Screenshot: URL removed from here as it's a student image share site

URL:
https://www.coursera.org/learn/database-applications-php/supplement/J3JH0/assignment-specification-autos-database

Asked student to try a forced browser reload, adding a dummy ?rl=0 to the Coursera URL, try a different browser so it's not cached locally