### PR TITLE
Update order of images to match instructions

### DIFF
--- a/lessons.json
+++ b/lessons.json
@@ -391,11 +391,11 @@
   "assignment":"{apphome}/assn/install/",
   "parts":[
     {
-      "title":"Image (JPG or PNG) of your php.ini display_errors setting (Maximium 1MB per file)",
+      "title":"Image (JPG or PNG) of PHPMyAdmin with the results of your SELECT statement (Maximium 1MB per file)",
       "type":"image"
     },
     {
-      "title":"Image (JPG or PNG) of PHPMyAdmin with the results of your SELECT statement (Maximium 1MB per file)",
+      "title":"Image (JPG or PNG) of your php.ini display_errors setting (Maximium 1MB per file)",
       "type":"image"
     }
   ],


### PR DESCRIPTION
In the instructions wa4e.com & Coursera the 2 images, described as "1st for the assignment" and "2nd in the peer-graded", are shown as 1) pma with date 2) php.ini. The assignment submission page is the opposite, 1) php.ini and 2) pma. Switch the 2 titles around to match instructions.  A few students have commented on this.