### PR TITLE
Open SUNY site renamed, SSL cert untrustworthy

### DIFF
--- a/assn/install/index.htm
+++ b/assn/install/index.htm
@@ -45,12 +45,12 @@ Screencast: <a href="http://tinyurl.com/mp29ab" target="_blank">Macintosh</a></l
 You should practice taking a few screen shots on your computer and saving them as PNG or JPG files.
 </li>
 <li> Chapters 1, 3, 4, 37, 39, and 41 from the free textbook
-<a href="http://textbooks.opensuny.org/the-missing-link-an-introduction-to-web-development-and-programming/"
+<a href="https://milneopentextbooks.org/the-missing-link-an-introduction-to-web-development-and-programming/"
 target="_blank">The Missing Link: An Introduction to Web Development and Programming</a> written by
-<a href="http://textbooks.opensuny.org/author/mmendez/" target="_blank">Michael Menendez</a>
+<a href="https://milneopentextbooks.org/author/mmendez/" target="_blank">Michael Menendez</a>
 and published by
-<a href="http://textbooks.opensuny.org/the-missing-link-an-introduction-to-web-development-and-programming/" 
-target="_blank">Open SUNY Textbooks</a>.
+<a href="https://milneopentextbooks.org/" 
+target="_blank">Milne Open Textbooks</a>.
 <li>Lectures and materials on <i> Introduction to Structured Query Language</i> from
 <a href="http://www.wa4e.com" target="_blank">www.wa4e.com</a></li>
 </ul>


### PR DESCRIPTION
Changes to 3rd party site rename & brand. Update link to new URL. 1st link and 3rd both pointed to book, rather then 3rd to published by. Update text to Milne.
SSL Cert reported by Kaspersky Internet Security,
You were protected from visiting this website by Kaspersky security. You can close this window with no risk.
Hide details
Detected at: 15/09/2021 19:01:20
URL: textbooks.opensuny.org
Reason: Invalid name of certificate. Either the name is not on the allowed list, or was explicitly excluded. View certificate
