### PR TITLE
Update rps.php

### DIFF
--- a/tools/autograder/rps.php
+++ b/tools/autograder/rps.php
@@ -65,7 +65,7 @@ line_out("-- if your fields do not match these, the next tests will fail.");
 
 
 
-line_out("Attempting a bad login $account pass=badsecret42.");
+line_out("Attempting a bad login $account pass=badsecret42");
 $form->setValues(array("who" => $account, "pass" => "badsecret42"));
 $crawler = $client->submit($form);
 markTestPassed('Submit bad login values to login.php');
@@ -89,7 +89,7 @@ if ( stripos($html,'Incorrect password') > 0 ) {
     error_out("Could not find 'Incorrect password'"); 
 }
 
-line_out("Attempting a proper login with pw=php123.");
+line_out("Attempting a proper login with pass=php123");
 $form->setValues(array("who" => $account, "pass" => "php123"));
 $crawler = $client->submit($form);
 markTestPassed('Submit good login values to login.php');


### PR DESCRIPTION
Non English speaker, entering password as "php123." the only 2 lines in the report ending "." are the 2 password ones. Also it was, "pass=" and "pw=", change pw to pass, so both lines and this match,

-- this autograder expects the log in form field names to be:
-- who and pass
