### PR TITLE
Update SQL-02-MySQL-Design-Handout.txt

### DIFF
--- a/lectures/SQL-02-MySQL-Design-Handout.txt
+++ b/lectures/SQL-02-MySQL-Design-Handout.txt
@@ -1,10 +1,10 @@
-CREATE DATABASE Music DEFAULT CHARACTER SET utf8;
+CREATE DATABASE Music DEFAULT CHARACTER SET utf8mb4;
 
 USE Music;  (Command line only)
 
 CREATE TABLE Artist (
   artist_id INTEGER NOT NULL AUTO_INCREMENT,
-  name VARCHAR(255),
+  `name` VARCHAR(255),
   PRIMARY KEY(artist_id)
 ) ENGINE = InnoDB;
 
@@ -23,7 +23,7 @@ CREATE TABLE Album (
 
 CREATE TABLE Genre (
   genre_id INTEGER NOT NULL AUTO_INCREMENT,
-  name VARCHAR(255),
+  `name` VARCHAR(255),
   PRIMARY KEY(genre_id)
 ) ENGINE = InnoDB;
 
@@ -32,7 +32,7 @@ CREATE TABLE Track (
   title VARCHAR(255),
   len INTEGER,
   rating INTEGER,
-  count INTEGER,
+  `count` INTEGER,
   album_id INTEGER,
   genre_id INTEGER,
 
@@ -46,32 +46,32 @@ CREATE TABLE Track (
 ) ENGINE = InnoDB;
 
 
-INSERT INTO Artist (name) VALUES ('Led Zepplin');
-INSERT INTO Artist (name) VALUES ('AC/DC');
+INSERT INTO Artist (`name`) VALUES ('Led Zepplin');
+INSERT INTO Artist (`name`) VALUES ('AC/DC');
 
-INSERT INTO Genre (name) VALUES ('Rock');
-INSERT INTO Genre (name) VALUES ('Metal');
+INSERT INTO Genre (`name`) VALUES ('Rock');
+INSERT INTO Genre (`name`) VALUES ('Metal');
 
 INSERT INTO Album (title, artist_id) VALUES ('Who Made Who', 2);
 INSERT INTO Album (title, artist_id) VALUES ('IV', 1);
 
-INSERT INTO Track (title, rating, len, count, album_id, genre_id)
+INSERT INTO Track (title, rating, len, `count`, album_id, genre_id)
     VALUES ('Black Dog', 5, 297, 0, 2, 1);
-INSERT INTO Track (title, rating, len, count, album_id, genre_id)
+INSERT INTO Track (title, rating, len, `count`, album_id, genre_id)
     VALUES ('Stairway', 5, 482, 0, 2, 1);
-INSERT INTO Track (title, rating, len, count, album_id, genre_id)
+INSERT INTO Track (title, rating, len, `count`, album_id, genre_id)
     VALUES ('About to Rock', 5, 313, 0, 1, 2);
-INSERT INTO Track (title, rating, len, count, album_id, genre_id)
+INSERT INTO Track (title, rating, len, `count`, album_id, genre_id)
     VALUES ('Who Made Who', 5, 207, 0, 1, 2);
 
 SELECT Album.title, Artist.name FROM Album JOIN Artist ON
-    Album.artist_id = Artist.artist_id
+    Album.artist_id = Artist.artist_id;
 
 SELECT Album.title, Album.artist_id, Artist.artist_id, Artist.name 
-    FROM Album JOIN Artist ON Album.artist_id = Artist.artist_id
+    FROM Album JOIN Artist ON Album.artist_id = Artist.artist_id;
 
 SELECT Track.title, Track.genre_id, Genre.genre_id, Genre.name 
-    FROM Track JOIN Genre
+    FROM Track JOIN Genre;
 
 SELECT Track.title, Genre.name FROM Track JOIN Genre ON 
     Track.genre_id = Genre.genre_id;
@@ -79,47 +79,47 @@ SELECT Track.title, Genre.name FROM Track JOIN Genre ON
 SELECT Track.title, Artist.name, Album.title, Genre.name 
     FROM Track JOIN Genre JOIN Album JOIN Artist 
     ON Track.genre_id = Genre.genre_id AND Track.album_id = 
-    Album.album_id AND Album.artist_id = Artist.artist_id
+    Album.album_id AND Album.artist_id = Artist.artist_id;
 
-DELETE FROM Genre WHERE name = 'Metal'
+DELETE FROM Genre WHERE `name` = 'Metal';
 
 DROP TABLE Track; DROP TABLE Album; DROP TABLE Genre; DROP TABLE Artist;
 
 Fresh Database...
 
-CREATE DATABASE Learning DEFAULT CHARACTER SET utf8 ;
+CREATE DATABASE Learning DEFAULT CHARACTER SET utf8mb4;
 
 USE Learning;   (Command line only)
 
-CREATE TABLE Account (
+CREATE TABLE `Account` (
     account_id  INTEGER NOT NULL AUTO_INCREMENT,
     email       VARCHAR(128) UNIQUE,
-    name        VARCHAR(128),
+    `name`        VARCHAR(128),
     PRIMARY KEY(account_id)
-) ENGINE=InnoDB CHARACTER SET=utf8;
+) ENGINE=InnoDB CHARACTER SET=utf8mb4;
 
 CREATE TABLE Course (
     course_id     INTEGER NOT NULL AUTO_INCREMENT,
     title         VARCHAR(128) UNIQUE,
     PRIMARY KEY(course_id)
-) ENGINE=InnoDB CHARACTER SET=utf8;
+) ENGINE=InnoDB CHARACTER SET=utf8mb4;
 
 CREATE TABLE Member (
     account_id    INTEGER,
     course_id     INTEGER,
     role          INTEGER,
 
-    CONSTRAINT FOREIGN KEY (account_id) REFERENCES Account (account_id)
+    CONSTRAINT FOREIGN KEY (account_id) REFERENCES `Account` (account_id)
       ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT FOREIGN KEY (course_id) REFERENCES Course (course_id)
        ON DELETE CASCADE ON UPDATE CASCADE,
 
     PRIMARY KEY (account_id, course_id)
-) ENGINE=InnoDB CHARACTER SET=utf8;
+) ENGINE=InnoDB CHARACTER SET=utf8mb4;
 
-INSERT INTO Account (name, email) VALUES ('Jane', 'jane@tsugi.org');
-INSERT INTO Account (name, email) VALUES ('Ed', 'ed@tsugi.org');
-INSERT INTO Account (name, email) VALUES ('Sue', 'sue@tsugi.org');
+INSERT INTO `Account` (`name`, email) VALUES ('Jane', 'jane@tsugi.org');
+INSERT INTO `Account` (`name`, email) VALUES ('Ed', 'ed@tsugi.org');
+INSERT INTO `Account` (`name`, email) VALUES ('Sue', 'sue@tsugi.org');
 
 INSERT INTO Course (title) VALUES ('Python');
 INSERT INTO Course (title) VALUES ('SQL');
@@ -135,11 +135,11 @@ INSERT INTO Member (account_id, course_id, role) VALUES (2, 2, 1);
 INSERT INTO Member (account_id, course_id, role) VALUES (2, 3, 1);
 INSERT INTO Member (account_id, course_id, role) VALUES (3, 3, 0);
 
-SELECT Account.name, Member.role, Course.title
-  FROM Account JOIN Member JOIN Course
-  ON Member.account_id = Account.account_id
+SELECT `Account`.name, Member.role, Course.title
+  FROM `Account` JOIN Member JOIN Course
+  ON Member.account_id = `Account`.account_id
     AND Member.course_id = Course.course_id
-  ORDER BY Course.title, Member.role DESC, Account.name
+  ORDER BY Course.title, Member.role DESC, `Account`.name;
 
 
 


### PR DESCRIPTION
MySQL 8.0. Some students have discovered phpMyAdmin, SQL, Format edits the code. Currently converts keywords, https://dev.mysql.com/doc/refman/8.0/en/keywords.html , to uppercase.  They are "name", "Account" and the function "count". To prevent phpMyAdmin from editing these, although they are not reserved words, use backticks. Update the utf8 alias as per the message - "Warning: #3719 'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous. " Add ; to the end of multiple lines for consistency. Note - as the SQL isn't written all in lowercase, at this time decided not to enclose every table & column name in backticks. This may raise questions for lines like - "INSERT INTO `Account` (`name`, email) VALUES" where email is okay. All backticks ref https://devtut.github.io/mysql/backticks.html#backticks-usage Tested on - 
a) Win 11 x64Pro 22H2, MySQL 5.6.34 phpMyAdmin 4.7.0 b) Ubuntu 20.04 x64 MySQL 8.0.30 phpMyAdmin 5.2.0