### PR TITLE
Update for issue #28, PK warning & utf8mb4

### DIFF
--- a/code/crud/NOTES.txt
+++ b/code/crud/NOTES.txt
@@ -1,6 +1,6 @@
 To get started run the following SQL commands:
 
-CREATE DATABASE misc;
+CREATE DATABASE misc CHARACTER SET=utf8mb4;
 CREATE USER 'fred'@'localhost' IDENTIFIED BY 'zap';
 GRANT ALL ON misc.* TO 'fred'@'localhost';
 CREATE USER 'fred'@'127.0.0.1' IDENTIFIED BY 'zap';

--- a/code/crud/NOTES.txt
+++ b/code/crud/NOTES.txt
@@ -1,18 +1,19 @@
 To get started run the following SQL commands:
 
 CREATE DATABASE misc;
-GRANT ALL ON misc.* TO 'fred'@'localhost' IDENTIFIED BY 'zap';
-GRANT ALL ON misc.* TO 'fred'@'127.0.0.1' IDENTIFIED BY 'zap';
+CREATE USER 'fred'@'localhost' IDENTIFIED BY 'zap';
+GRANT ALL ON misc.* TO 'fred'@'localhost';
+CREATE USER 'fred'@'127.0.0.1' IDENTIFIED BY 'zap';
+GRANT ALL ON misc.* TO 'fred'@'127.0.0.1';
 
 USE misc; (Or select misc in phpMyAdmin)
 
 CREATE TABLE users (
    user_id INTEGER NOT NULL
-     AUTO_INCREMENT KEY,
+     AUTO_INCREMENT,
    name VARCHAR(128),
    email VARCHAR(128),
    password VARCHAR(128),
+   PRIMARY KEY(user_id),
    INDEX(email)
-) ENGINE=InnoDB CHARSET=utf8;
-
-
+) ENGINE=InnoDB CHARSET=utf8mb4;


### PR DESCRIPTION
Tested on - 
a) Win 11 x64Pro 22H2, MySQL 5.6.34 phpMyAdmin 4.7.0 b) Ubuntu 20.04 x64 MySQL 8.0.30 phpMyAdmin 5.2.0
Remove phpMyAdmin warning, "A comma or a closing bracket was expected. (near KEY)" , for lines 3-5 and update utf8 to utf8mb4.