### PR TITLE
Fixed dead YouTube link.

### DIFF
--- a/lessons.json
+++ b/lessons.json
@@ -816,7 +816,7 @@
         },
         {
             "title": "Bonus: Elizabeth Fong - Creating the SQL Database Standards",
-            "href" : "https://www.youtube.com/watch?v=rLUm3vst87"
+            "href" : "https://www.youtube.com/watch?v=rLUm3vst87g"
         }
     ],
     "lti" : [


### PR DESCRIPTION
Fixed dead YouTube link that was missing a character at the end of the video id.