### PR TITLE
Fix Typo in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,7 +51,7 @@ You can take this course and receive a certificate at:
 <ul>
 <li><a href="https://www.coursera.org/specializations/web-applications" target="_blank">Coursera: Web Applications for Everybody Specialization</a> </li>
 <li><a href="https://www.youtube.com/watch?v=xr6uZDRTna0" target="_blank">FreeCodeCamp: Web Applications for Everybody</a>
-<li><a href="https://online.umich.edu/series/web-applications-for-everybody/" target="_blank">Free certificates for University of Michgan students and staff</a></li>
+<li><a href="https://online.umich.edu/series/web-applications-for-everybody/" target="_blank">Free certificates for University of Michigan students and staff</a></li>
 </ul>
 If you <a href="tsugi/login.php">log in</a> to this site
 you have joined a free, global


### PR DESCRIPTION
Fix to WA4E website landing page's index.php: "Michgan" typo in certification link changed to "Michigan"